### PR TITLE
Pass OTP over PRSH

### DIFF
--- a/source/ancast.c
+++ b/source/ancast.c
@@ -933,10 +933,11 @@ u32 ancast_plugins_load(const char* plugins_fpath)
     if(minute_on_slc || (!minute_on_sd && sdcard_check_card() == SDMMC_NO_CARD))
         prsh_set_entry("minute_on_slc", NULL, 0);
 
-    if(crypto_otp_is_de_Fused){
+    if(crypto_otp_is_de_Fused || redotp){
         config_plugin_base = ancast_plugin_next;
-        ancast_plugin_next = ancast_plugin_data_copy(ancast_plugin_next, (uint8_t*)&otp, sizeof(otp));
-        prsh_set_entry("otp", (void*)(config_plugin_base+IPX_DATA_START), sizeof(otp));
+        otp_t *o = redotp?redotp:&otp;
+        ancast_plugin_next = ancast_plugin_data_copy(ancast_plugin_next, o, sizeof(*o));
+        prsh_set_entry("otp", (void*)(config_plugin_base+IPX_DATA_START), sizeof(*o));
     }
 
     return 0;

--- a/source/ancast.c
+++ b/source/ancast.c
@@ -933,6 +933,12 @@ u32 ancast_plugins_load(const char* plugins_fpath)
     if(minute_on_slc || (!minute_on_sd && sdcard_check_card() == SDMMC_NO_CARD))
         prsh_set_entry("minute_on_slc", NULL, 0);
 
+    if(crypto_otp_is_de_Fused){
+        config_plugin_base = ancast_plugin_next;
+        ancast_plugin_next = ancast_plugin_data_copy(ancast_plugin_next, (uint8_t*)&otp, sizeof(otp));
+        prsh_set_entry("otp", (void*)(config_plugin_base+IPX_DATA_START), sizeof(otp));
+    }
+
     return 0;
 }
 #endif

--- a/source/fatfs/elm.c
+++ b/source/fatfs/elm.c
@@ -140,7 +140,7 @@ static TCHAR* _ELM_mbstoucs2(const char* src, size_t* len)
     int bytes;
     TCHAR* dst = CvtBuf;
 
-    while (src != '\0')
+    while (*src != '\0')
     {
         bytes = mbrtowc(&tempChar, src, MB_CUR_MAX, &ps);
 

--- a/source/isfs.c
+++ b/source/isfs.c
@@ -397,14 +397,20 @@ static isfs_fst* _isfs_get_fst(isfs_ctx* ctx)
 
 int isfs_load_keys(isfs_ctx* ctx)
 {
+    otp_t *o = &otp;
+    if(ctx->bank & 0x80000000 && redotp){
+        printf("ISFS: using redotp\n");
+        o = redotp;
+    }
+
     switch(ctx->version) {
         case 0:
-            memcpy(ctx->aes, otp.wii_nand_key, sizeof(ctx->aes));
-            memcpy(ctx->hmac, otp.wii_nand_hmac, sizeof(ctx->hmac));
+            memcpy(ctx->aes, o->wii_nand_key, sizeof(ctx->aes));
+            memcpy(ctx->hmac, o->wii_nand_hmac, sizeof(ctx->hmac));
             break;
         case 1:
-            memcpy(ctx->aes, otp.nand_key, sizeof(ctx->aes));
-            memcpy(ctx->hmac, otp.nand_hmac, sizeof(ctx->hmac));
+            memcpy(ctx->aes, o->nand_key, sizeof(ctx->aes));
+            memcpy(ctx->hmac, o->nand_hmac, sizeof(ctx->hmac));
             break;
         default:
             printf("ISFS: Unknown super block version %u!\n", ctx->version);

--- a/source/main.c
+++ b/source/main.c
@@ -958,55 +958,6 @@ skip_menu:
         case 3: smc_reset_no_defuse(); break;
     }
 
-    if (boot.needs_otp)
-    {
-        if (boot.is_patched)
-        {
-            printf("Searching for OTP store in patch...\n");
-            u32* search = (u32*)0x20;
-            for (int i = 0; i < 0x800000; i += 4) {
-                if (search[0] == 0x4F545053) {
-                    if (search[2] == 0x4F545053 && search[1] == 0x544F5245 && search[3] == 0x544F5245) {
-                        printf("OTP store at: %08x\n", (u32)search);
-                        memcpy((void*)search, &otp, sizeof(otp));
-                        break;
-                    }
-                }
-                search++;
-            }
-        }
-        else {
-            printf("Searching for OTP store in IOS...\n");
-            u32* search = (u32*)0x01000200;
-            for (int i = 0; i < 0x1000000; i += 4) {
-                if (search[0] == 0x4F545053) {
-                    if (search[2] == 0x4F545053 && search[1] == 0x544F5245 && search[3] == 0x544F5245) {
-                        printf("OTP store at: %08x\n", (u32)search);
-                        memcpy((void*)search, &otp, sizeof(otp));
-                        break;
-                    }
-                }
-                search++;
-            }
-        }
-
-        if (read32(MAGIC_PLUG_ADDR) == MAGIC_PLUG && ancast_plugins_base)
-        {
-            printf("Searching for OTP store in plugins...\n");
-            u32* search = (u32*)ancast_plugins_base;
-            for (int i = 0; i < CARVEOUT_SZ; i += 4) {
-                if (search[0] == 0x4F545053) {
-                    if (search[2] == 0x4F545053 && search[1] == 0x544F5245 && search[3] == 0x544F5245) {
-                        printf("OTP store at: %08x\n", (u32)search);
-                        memcpy((void*)search, &otp, sizeof(otp));
-                        break;
-                    }
-                }
-                search++;
-            }
-        }
-    }
-
     // WiiU-Firmware-Emulator JIT bug
     void (*boot_vector)(void) = (void*)boot.vector;
     boot_vector();

--- a/source/rednand.c
+++ b/source/rednand.c
@@ -263,6 +263,8 @@ static int rednand_load_opt(void){
 
 void clear_rednand(void){
     memset(&rednand, 0, sizeof(rednand));
+    if(redotp)
+        free(redotp);
 }
 
 int init_rednand(void){

--- a/source/rednand.c
+++ b/source/rednand.c
@@ -258,7 +258,7 @@ static int rednand_load_opt(void){
         redotp = NULL;
         return -2;
     }
-    memcopy(redotp->seeprom_key, otp.seeprom_key, sizeof(otp.seeprom_key));
+    memcpy(redotp->seeprom_key, otp.seeprom_key, sizeof(otp.seeprom_key));
     return 1;
 }
 
@@ -283,7 +283,7 @@ int init_rednand(void){
     if(apply_error < 0)
         return -3;
 
-    int redotp_error = rednand_load_opt;
+    int redotp_error = rednand_load_opt();
     if(redotp_error < 0){
         return -4;
     }

--- a/source/rednand.c
+++ b/source/rednand.c
@@ -258,6 +258,7 @@ static int rednand_load_opt(void){
         redotp = NULL;
         return -2;
     }
+    memcopy(redotp->seeprom_key, otp.seeprom_key, sizeof(otp.seeprom_key));
     return 1;
 }
 

--- a/source/rednand.h
+++ b/source/rednand.h
@@ -1,6 +1,8 @@
 #include "rednand_config.h"
+#include "crypto.h"
 
 extern rednand_config rednand;
+extern otp_t *redotp;
 
 int init_rednand(void);
 


### PR DESCRIPTION
Places the OTP into the ramdisk carveout and places the pointer to it into PRSH, if the console is defused or redNAND is booted and a redotp.bin exists